### PR TITLE
setParam tested for edge cases

### DIFF
--- a/Source/CliApp.cpp
+++ b/Source/CliApp.cpp
@@ -411,12 +411,12 @@ void CLIApp::onRunning()
     File prefsDir = engine.getPropertyStorage().getAppPrefsFolder();
 
     File defaultPresetDir = prefsDir.getChildFile(CYBR_PRESET);
-//    CybrSearchPath presetSearchPath(CYBR_PRESET);
-//    presetSearchPath.init(cApp, defaultPresetDir.getFullPathName());
+    CybrSearchPath presetSearchPath(CYBR_PRESET);
+    presetSearchPath.init(cApp, defaultPresetDir.getFullPathName());
 
     File defaultSampleDir = prefsDir.getChildFile(CYBR_SAMPLE);
-//    CybrSearchPath sampleSearchPath(CYBR_SAMPLE);
-//    sampleSearchPath.init(cApp, defaultSampleDir.getFullPathName());
+    CybrSearchPath sampleSearchPath(CYBR_SAMPLE);
+    sampleSearchPath.init(cApp, defaultSampleDir.getFullPathName());
 
     // Because of the while loop below, we must not use the "default command"
     // functionality built into the juce::ConsoleApplication class. If there is

--- a/Source/CliApp.cpp
+++ b/Source/CliApp.cpp
@@ -411,12 +411,12 @@ void CLIApp::onRunning()
     File prefsDir = engine.getPropertyStorage().getAppPrefsFolder();
 
     File defaultPresetDir = prefsDir.getChildFile(CYBR_PRESET);
-    CybrSearchPath presetSearchPath(CYBR_PRESET);
-    presetSearchPath.init(cApp, defaultPresetDir.getFullPathName());
+//    CybrSearchPath presetSearchPath(CYBR_PRESET);
+//    presetSearchPath.init(cApp, defaultPresetDir.getFullPathName());
 
     File defaultSampleDir = prefsDir.getChildFile(CYBR_SAMPLE);
-    CybrSearchPath sampleSearchPath(CYBR_SAMPLE);
-    sampleSearchPath.init(cApp, defaultSampleDir.getFullPathName());
+//    CybrSearchPath sampleSearchPath(CYBR_SAMPLE);
+//    sampleSearchPath.init(cApp, defaultSampleDir.getFullPathName());
 
     // Because of the while loop below, we must not use the "default command"
     // functionality built into the juce::ConsoleApplication class. If there is

--- a/Source/FluidOscServer.cpp
+++ b/Source/FluidOscServer.cpp
@@ -430,9 +430,9 @@ void FluidOscServer::handleSamplerMessage(const OSCMessage &message) {
             filePath = file.getFullPathName(); // Found it!
         } else {
             // Look in the sample search path.
-//            file = CybrSearchPath(CYBR_SAMPLE).find(filePath);
-//            if (file != File()) filePath = file.getFullPathName(); // Found it!
-//            else std::cout << "Warning: sampler trying to add sampler sound, but file not found: " << filePath << std::endl;
+            file = CybrSearchPath(CYBR_SAMPLE).find(filePath);
+            if (file != File()) filePath = file.getFullPathName(); // Found it!
+            else std::cout << "Warning: sampler trying to add sampler sound, but file not found: " << filePath << std::endl;
         }
 
         sampler->addSound(filePath, soundName, 0, 0, gain);

--- a/Source/FluidOscServer.cpp
+++ b/Source/FluidOscServer.cpp
@@ -151,7 +151,9 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
         !message[0].isString() ||
         !message[1].isFloat32() ||
         !message[2].isFloat32() ||
-        !message[3].isFloat32()) return;
+        !message[3].isFloat32()){
+        std::cout<<"Setting parameter failed. Not enough arguments."<<std::endl;
+        return;}
         
     if (!selectedPlugin) return;
 

--- a/Source/FluidOscServer.cpp
+++ b/Source/FluidOscServer.cpp
@@ -174,7 +174,7 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
             curve.addPoint(changeTime, paramValue, curveValue);
             curve.removeRedundantPoints(te::EditTimeRange(0, curve.getLength()+1));
             
-            std::cout << "set " << paramName << " to " << param->valueToString(paramValue) << " at time " << changeQuarterNote <<" Quarter Notes."<< std::endl;
+            std::cout << "set " << paramName << " to " << param->valueToString(paramValue) << " at " << changeQuarterNote <<" Quarter Notes."<< std::endl;
             break;
         }
     }

--- a/Source/FluidOscServer.cpp
+++ b/Source/FluidOscServer.cpp
@@ -156,7 +156,7 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
 
     String paramName = message[0].getString();
     float paramValue = message[1].getFloat32();
-    float changeTime = message[2].getFloat32();
+    double changeTime = (double)message[2].getFloat32();
 
     for (te::AutomatableParameter* param : selectedPlugin->getAutomatableParameters()) {
         if (param->paramName.equalsIgnoreCase(paramName)) {
@@ -165,8 +165,14 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
                 param->getCurve().addPoint(0, param->getCurrentValue(), 0);
             }
             
+            te::AutomationCurve curve = param->getCurve();
+            if (curve.getValueAt(changeTime) == paramValue){
+                std::cout << paramName << " already has value " << paramValue << " at time " << changeTime << std::endl;
+                continue;
+            }
+            
             param->getCurve().addPoint(changeTime, paramValue, 0);
-            std::cout << "set " << paramName << " to " << paramValue << " explicitvalue: " << param->getCurrentExplicitValue() << " value: " << param->getCurrentValue() << std::endl;
+            std::cout << "set " << paramName << " to " << paramValue << " at time " << changeTime << std::endl;
             break;
         }
     }
@@ -422,9 +428,9 @@ void FluidOscServer::handleSamplerMessage(const OSCMessage &message) {
             filePath = file.getFullPathName(); // Found it!
         } else {
             // Look in the sample search path.
-            file = CybrSearchPath(CYBR_SAMPLE).find(filePath);
-            if (file != File()) filePath = file.getFullPathName(); // Found it!
-            else std::cout << "Warning: sampler trying to add sampler sound, but file not found: " << filePath << std::endl;
+//            file = CybrSearchPath(CYBR_SAMPLE).find(filePath);
+//            if (file != File()) filePath = file.getFullPathName(); // Found it!
+//            else std::cout << "Warning: sampler trying to add sampler sound, but file not found: " << filePath << std::endl;
         }
 
         sampler->addSound(filePath, soundName, 0, 0, gain);

--- a/Source/FluidOscServer.cpp
+++ b/Source/FluidOscServer.cpp
@@ -157,10 +157,23 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
 
     String paramName = message[0].getString();
     float normalizedValue = message[1].getFloat32();
+    if (normalizedValue > 1 || normalizedValue < 0){
+        std::cout<<"Setting parameter " << paramName << " failed. Normalized value has to be between 0 and 1."<<std::endl;
+        return;
+    }
+    
     double changeQuarterNote = (double)message[2].getFloat32();
-    float curveValue = message[3].getFloat32();
+    if (changeQuarterNote < 0){
+        std::cout<<"Setting parameter " << paramName << " failed. Time has to be a positive number."<<std::endl;
+        return;
+    }
     double changeTime = activeCybrEdit->getEdit().tempoSequence.beatsToTime(changeQuarterNote);
     
+    float curveValue = message[3].getFloat32();
+    if (curveValue > 1 || curveValue < -1){
+        std::cout<<"Setting parameter " << paramName << " failed. Curve has to be between -1 and 1."<<std::endl;
+        return;
+    }
 
     for (te::AutomatableParameter* param : selectedPlugin->getAutomatableParameters()) {
         if (param->paramName.equalsIgnoreCase(paramName)) {
@@ -174,7 +187,7 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
             curve.addPoint(changeTime, paramValue, curveValue);
             curve.removeRedundantPoints(te::EditTimeRange(0, curve.getLength()+1));
             
-            std::cout << "set " << paramName << " to " << param->valueToString(paramValue) << " at " << changeQuarterNote <<" Quarter Notes."<< std::endl;
+            std::cout << "set " << paramName << " to " << param->valueToString(paramValue) << " at " << changeQuarterNote <<" Quarter Note(s)."<< std::endl;
             break;
         }
     }

--- a/Source/FluidOscServer.cpp
+++ b/Source/FluidOscServer.cpp
@@ -174,7 +174,7 @@ void FluidOscServer::setPluginParam(const OSCMessage& message) {
             curve.addPoint(changeTime, paramValue, curveValue);
             curve.removeRedundantPoints(te::EditTimeRange(0, curve.getLength()+1));
             
-            std::cout << "set " << paramName << " to " << param->valueToString(paramValue) << " at time " << changeTime <<"s"<< std::endl;
+            std::cout << "set " << paramName << " to " << param->valueToString(paramValue) << " at time " << changeQuarterNote <<" Quarter Notes."<< std::endl;
             break;
         }
     }

--- a/fluid-client/examples/plugin-setparam-time.js
+++ b/fluid-client/examples/plugin-setparam-time.js
@@ -7,10 +7,12 @@ const sessionPath = path.join(__dirname, 'sessions/out.tracktionedit')
 
 const client = new FluidClient(9999);
 client.send([
+  fluid.global.activate(sessionPath, true),
   fluid.audiotrack.select('stabs'),
   fluid.plugin.select('4osc'),
-  fluid.plugin.setParam('Amp Attack', 5, 1), //debug to see if i need to make it work with beats
-  fluid.plugin.setParam('Amp Attack', 5, 1), //same point reappears 
+  fluid.plugin.setParam('Amp Attack', 50, 1), //debug to see if i need to make it work with beats
+  fluid.plugin.setParam('Amp Attack', 3, 1), //same point reappears 
+  fluid.plugin.setParam('Amp Attack', 25, 1), //same point reappears 
   fluid.plugin.setParam('Width', 0.75, 4),
   ...fluid.midiclip.create('v1.1', 0, 8, tabs.noTearsVerseNotes),
   fluid.global.save(sessionPath),

--- a/fluid-client/examples/plugin-setparam-time.js
+++ b/fluid-client/examples/plugin-setparam-time.js
@@ -10,7 +10,7 @@ client.send([
   fluid.global.activate(sessionPath, true),
   fluid.audiotrack.select('stabs'),
   fluid.plugin.select('4osc'),
-  fluid.plugin.setParam('Amp Attack', 0.1, 1), 
+  fluid.plugin.setParam('Amp Attack', 0.8, 1, 0.3), 
   ...fluid.midiclip.create('v1.1', 0, 8, tabs.noTearsVerseNotes),
   fluid.global.save(sessionPath),
 ]);

--- a/fluid-client/examples/plugin-setparam-time.js
+++ b/fluid-client/examples/plugin-setparam-time.js
@@ -10,10 +10,7 @@ client.send([
   fluid.global.activate(sessionPath, true),
   fluid.audiotrack.select('stabs'),
   fluid.plugin.select('4osc'),
-  fluid.plugin.setParam('Amp Attack', 50, 1), //debug to see if i need to make it work with beats
-  fluid.plugin.setParam('Amp Attack', 3, 1), //same point reappears 
-  fluid.plugin.setParam('Amp Attack', 25, 1), //same point reappears 
-  fluid.plugin.setParam('Width', 0.75, 4),
+  fluid.plugin.setParam('Amp Attack', 0.1, 1), 
   ...fluid.midiclip.create('v1.1', 0, 8, tabs.noTearsVerseNotes),
   fluid.global.save(sessionPath),
 ]);

--- a/fluid-client/examples/plugin-setparam-time.js
+++ b/fluid-client/examples/plugin-setparam-time.js
@@ -9,8 +9,8 @@ const client = new FluidClient(9999);
 client.send([
   fluid.audiotrack.select('stabs'),
   fluid.plugin.select('4osc'),
-  fluid.plugin.setParam('Amp Attack', 5, 1),
-  fluid.plugin.setParam('Amp Attack', 5, 1),
+  fluid.plugin.setParam('Amp Attack', 5, 1), //debug to see if i need to make it work with beats
+  fluid.plugin.setParam('Amp Attack', 5, 1), //same point reappears 
   fluid.plugin.setParam('Width', 0.75, 4),
   ...fluid.midiclip.create('v1.1', 0, 8, tabs.noTearsVerseNotes),
   fluid.global.save(sessionPath),

--- a/fluid-client/examples/plugin-setparam-time.js
+++ b/fluid-client/examples/plugin-setparam-time.js
@@ -1,0 +1,17 @@
+const fluid = require('../src/fluidOsc');
+const FluidClient = require('../src/FluidClient');
+const tabs = require('./tab-examples');
+const path = require('path');
+
+const sessionPath = path.join(__dirname, 'sessions/out.tracktionedit')
+
+const client = new FluidClient(9999);
+client.send([
+  fluid.audiotrack.select('stabs'),
+  fluid.plugin.select('4osc'),
+  fluid.plugin.setParam('Amp Attack', 5, 1),
+  fluid.plugin.setParam('Amp Attack', 5, 1),
+  fluid.plugin.setParam('Width', 0.75, 4),
+  ...fluid.midiclip.create('v1.1', 0, 8, tabs.noTearsVerseNotes),
+  fluid.global.save(sessionPath),
+]);

--- a/fluid-client/src/fluid/plugin.js
+++ b/fluid-client/src/fluid/plugin.js
@@ -29,6 +29,16 @@ const plugin = {
     return { args, address: '/plugin/select' };
   },
 
+  /**
+   * Changes the automation curve of the parameter value,
+   * adds a point to the curve at the specified value and time.
+   * The server automatically adds a point at the default value of the parameter at time 0.
+   *
+   * @param {string} paramName - the name of the parameter
+   * @param {number} normalizedValue - a normalized parameter value from 0 to 1
+   * @param {number} timeInQuarterNotes - time of parameter change in quarter notes
+   * @param {number} curve - the curvature of the line formed by this point and the next point
+   */
   setParam(paramName, normalizedValue, timeInQuarterNotes = 0, curve = 0) {
     if (typeof paramName !== 'string')
       throw new Error('plugin.setParam needs a parameterName, got: ' + paramName);

--- a/fluid-client/src/fluid/plugin.js
+++ b/fluid-client/src/fluid/plugin.js
@@ -29,16 +29,17 @@ const plugin = {
     return { args, address: '/plugin/select' };
   },
 
-  setParam(paramName, normalizedValue) {
+  setParam(paramName, value, time = 0) {
     if (typeof paramName !== 'string')
       throw new Error('plugin.setParam needs a parameterName, got: ' + paramName);
-    if (typeof normalizedValue !== 'number')
-      throw new Error('plugin.setParam needs a value number, got ' + normalizedValue);
+    if (typeof value !== 'number')
+      throw new Error('plugin.setParam needs a value number, got ' + value);
     return {
       address: '/plugin/param/set',
       args: [
         { type: 'string', value: paramName },
-        { type: 'float', value: normalizedValue },
+        { type: 'float', value: value },
+        { type: 'float', value: time },
       ],
     }
   },

--- a/fluid-client/src/fluid/plugin.js
+++ b/fluid-client/src/fluid/plugin.js
@@ -29,17 +29,23 @@ const plugin = {
     return { args, address: '/plugin/select' };
   },
 
-  setParam(paramName, value, time = 0) {
+  setParam(paramName, normalizedValue, timeInQuarterNotes = 0, curve = 0) {
     if (typeof paramName !== 'string')
       throw new Error('plugin.setParam needs a parameterName, got: ' + paramName);
-    if (typeof value !== 'number')
-      throw new Error('plugin.setParam needs a value number, got ' + value);
+    if (typeof normalizedValue !== 'number')
+      throw new Error('plugin.setParam needs a value number, got ' + normalizedValue);
+    if (typeof timeInQuarterNotes !== 'number')
+      throw new Error('plugin.setParam needs a time number, got ' + timeInQuarterNotes);
+    if (typeof curve !== 'number')
+      throw new Error('plugin.setParam needs a curve number, got ' + curve);
+
     return {
       address: '/plugin/param/set',
       args: [
         { type: 'string', value: paramName },
-        { type: 'float', value: value },
-        { type: 'float', value: time },
+        { type: 'float', value: normalizedValue },
+        { type: 'float', value: timeInQuarterNotes },
+        { type: 'float', value: curve },
       ],
     }
   },


### PR DESCRIPTION
setParam now uses a normalized value, for consistency. setParam also now works with time in quarter notes instead of seconds.

Since setParam accepts a normalized value, I checked for whether the normalized value provided is between 0 and 1 in addition to whether or not time is positive and curve is between -1 and 1. setParam also removes any redundant points using tracktion engine's inbuilt removeRedundantPoints function. 