### PR TITLE
Fixed Memory Leak

### DIFF
--- a/Source/FluidIpcServer.cpp
+++ b/Source/FluidIpcServer.cpp
@@ -30,6 +30,10 @@ InterprocessConnection* FluidIpcServer::createConnectionObject(){
 FluidIpcServer::FluidIpcServer(FluidOscServer& server) : fluidOscServer(&server){
 }
 
+void FluidIpcServer::removeIpcConn(int ipc_conn){
+    ipcMap.erase(ipc_conn);
+}
+
 //==============================================================================
 void FluidIpc::setFluidServer(FluidOscServer& server){
     fluidOscServer = &server;
@@ -41,7 +45,7 @@ void FluidIpc::setIpcServer(FluidIpcServer& server){
 
 void FluidIpc::connectionMade(){
     std::cout<<"Connection Made"<<std::endl;
-    fluidIpcServer->ipcMap.erase(ipc_num);
+    fluidIpcServer->removeIpcConn(ipc_num);
 }
 
 void FluidIpc::setIpcNum(int num){

--- a/Source/FluidIpcServer.cpp
+++ b/Source/FluidIpcServer.cpp
@@ -15,9 +15,16 @@
 InterprocessConnection* FluidIpcServer::createConnectionObject(){
     std::cout<<"Creating interprocess connection"<<std::endl;
     
+    while(ipcMap.find(ipc_num) != ipcMap.end()){
+        ipc_num += 1;
+        ipc_num %= threshold;
+    }
+        
     ipcMap[ipc_num].setFluidServer(*fluidOscServer);
-
-    return &ipcMap[ipc_num++];
+    ipcMap[ipc_num].setIpcServer(*this);
+    ipcMap[ipc_num].setIpcNum(ipc_num);
+    
+    return &ipcMap[ipc_num];
 }
 
 FluidIpcServer::FluidIpcServer(FluidOscServer& server) : fluidOscServer(&server){
@@ -28,8 +35,17 @@ void FluidIpc::setFluidServer(FluidOscServer& server){
     fluidOscServer = &server;
 }
 
+void FluidIpc::setIpcServer(FluidIpcServer& server){
+    fluidIpcServer = &server;
+}
+
 void FluidIpc::connectionMade(){
     std::cout<<"Connection Made"<<std::endl;
+    fluidIpcServer->ipcMap.erase(ipc_num);
+}
+
+void FluidIpc::setIpcNum(int num){
+    ipc_num = num;
 }
 
 void FluidIpc::connectionLost(){

--- a/Source/FluidIpcServer.h
+++ b/Source/FluidIpcServer.h
@@ -14,6 +14,9 @@
 #include "temp_OSCInputStream.h"
 #include "FluidOscServer.h"
 
+class FluidIpc;
+class FluidIpcServer;
+
 //==============================================================================
 class FluidIpc : public InterprocessConnection{
 public:
@@ -22,8 +25,12 @@ public:
     void messageReceived(const MemoryBlock& message) override;
     
     void setFluidServer(FluidOscServer& server);
+    void setIpcServer(FluidIpcServer& server);
+    void setIpcNum(int ipc_num);
 private:
+    int ipc_num;
     FluidOscServer* fluidOscServer = nullptr;
+    FluidIpcServer* fluidIpcServer = nullptr;
 };
 
 //==============================================================================
@@ -31,9 +38,10 @@ class FluidIpcServer : public InterprocessConnectionServer{
 public:
     FluidIpcServer(FluidOscServer& server);
     InterprocessConnection* createConnectionObject() override;
+    std::map<int, FluidIpc> ipcMap;
     
 private:
     int ipc_num = 0;
-    std::map<int, FluidIpc> ipcMap;
+    int threshold = 1000000000;
     FluidOscServer* fluidOscServer = nullptr;
 };

--- a/Source/FluidIpcServer.h
+++ b/Source/FluidIpcServer.h
@@ -38,10 +38,11 @@ class FluidIpcServer : public InterprocessConnectionServer{
 public:
     FluidIpcServer(FluidOscServer& server);
     InterprocessConnection* createConnectionObject() override;
-    std::map<int, FluidIpc> ipcMap;
+    void removeIpcConn(int ipc_conn_num);
     
 private:
     int ipc_num = 0;
     int threshold = 1000000000;
+    std::map<int, FluidIpc> ipcMap;
     FluidOscServer* fluidOscServer = nullptr;
 };


### PR DESCRIPTION
The IPC's were not being destroyed, so I made sure to remove the element from the map whenever the connection closes. Also, I added a threshold so we can only have up to 1,000,000,000 active connections at once.